### PR TITLE
Modify the naming of the compilation container

### DIFF
--- a/scripts/build_utils/oneshot.py
+++ b/scripts/build_utils/oneshot.py
@@ -14,11 +14,12 @@ python3 ./scripts/build_utils/oneshot.py --grammar=XXXParser.g4 --lexer=XXXLexer
 import argparse
 import os
 import subprocess
+import hashlib
 
 SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
 REPO_ROOT = SCRIPT_PATH + "/../../"
 IMG_NAME = "buzzbeebuild"
-CONTAINER_NAME = f"{IMG_NAME}_container"
+CONTAINER_NAME = f"{IMG_NAME}_container_" + hashlib.sha256(os.path.realpath(__file__).encode()).hexdigest()[:12]
 
 
 def run_cmd(cmd, check=True):


### PR DESCRIPTION
When the compilation container is created for the first time, the code file directory under the current directory A is mounted to /repo.

In the following case, when the user switches the project to another directory, for example, directory B, if the user runs oneshot.py again, the code files in directory B will not be compiled, and the user will be confused about the result if he/she does not look at the py file carefully.